### PR TITLE
Auto Feed Update feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # drop-feeds
-Drop feeds is a RSS and Atom feed reader webextension for Mozilla Firefox.
+Drop Feeds is a RSS and Atom feed reader webextension for Mozilla Firefox.
 It works with a folder tree in sidebar panel.
 

--- a/html/debug.html
+++ b/html/debug.html
@@ -4,7 +4,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <link href="/resources/css/debug.css" rel="stylesheet">
     <script src="/js/tools/browserManager.js"></script>
-    <title>Drop feeds (debug)</title>
+    <title>Drop Feeds (debug)</title>
   </head>
 
   <body>

--- a/html/options.html
+++ b/html/options.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <link href="/resources/css/options.css" rel="stylesheet">
-    <title>Drop feeds (options)</title>
+    <title>Drop Feeds (options)</title>
     <script src="/js/tools/defaultValues.js"></script>
     <script src="/js/tools/browserManager.js"></script>
     <script src="/js/tools/textTools.js"></script>
@@ -71,12 +71,23 @@
     <div id="updateCheckerTab" class="tabContent">
       <table>
         <tr>
-        <td><label>Timeout</label><input type="number" id="timeoutNumber" step="1" min="1" max="999"><span class="checkboxText">seconds</span></td>
-        &nbsp;&nbsp;
-        <td><input type="checkbox" id="asynchronousFeedCheckingCheckbox"><span class="checkboxText">Asynchronous feed checking</span></td>
-        <td><input type="checkbox" id="showFeedUpdatePopupCheckbox"><span class="checkboxText">Show notification popup after update</span></td>
-        <td><input type="checkbox" id="ifHttpsHasFailedRetryWithHttpCheckbox"><span class="checkboxText">If https failed then retry with http</span></td>
-      </tr>
+           <td><label>Timeout</label><input type="number" id="timeoutNumber" step="1" min="1" max="999"><span class="checkboxText">seconds</span></td>  
+        </tr>
+        <tr>
+           <td><input type="checkbox" id="asynchronousFeedCheckingCheckbox"><span class="checkboxText">Asynchronous feed checking</span></td>
+        </tr>
+        <tr>
+           <td>
+                <input type="checkbox" id="automaticFeedUpdatesCheckbox"><span class="checkboxText">Automatic feed updates every</span>
+                <input type="number" id="automaticFeedUpdateMinutesNumber" step="5" min="5" max="1440"><span class="checkboxText">minutes</span>
+           </td>
+        </tr>
+        <tr>
+            <td><input type="checkbox" id="showFeedUpdatePopupCheckbox"><span class="checkboxText">Show notification popup after update</span></td>
+        </tr>
+        <tr>
+            <td><input type="checkbox" id="ifHttpsHasFailedRetryWithHttpCheckbox"><span class="checkboxText">If https failed then retry with http</span></td>           
+        </tr>
       </table>
     </div>
 

--- a/html/sidebar.html
+++ b/html/sidebar.html
@@ -3,7 +3,7 @@
   <head>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Drop feeds (side panel)</title>
+    <title>Drop Feeds (side panel)</title>
     <link id="cssLink" href="/resources/themes/dauphine/css/sidebar.css" rel="stylesheet">
     <script src="/js/tools/defaultValues.js"></script>
     <script src="/js/tools/localStorageManager.js"></script>

--- a/html/subscribe.html
+++ b/html/subscribe.html
@@ -9,7 +9,7 @@
     <script src="/js/tools/browserManager.js"></script>
     <script src="/js/tools/textTools.js"></script>
     <script src="/js/themes/theme-subscribe.js"></script>
-    <title>Drop feeds (subscribe)</title>
+    <title>Drop Feeds (subscribe)</title>
   </head>
 
   <body>

--- a/js/independent/content-script.js
+++ b/js/independent/content-script.js
@@ -30,7 +30,7 @@ class ContentManager {
       let feedSubscribeLine = document.getElementById('feedSubscribeLine');
       let subscribeButton = document.createElement('button');
       subscribeButton.id = 'subscribeWithDropFeedsButton';
-      subscribeButton.innerText = 'Subscribe with Drop feeds';
+      subscribeButton.innerText = 'Subscribe with Drop Feeds';
       subscribeButton.style.display = 'block';
       subscribeButton.style.marginInlineStart = 'auto';
       subscribeButton.style.marginTop = '0.5em';

--- a/js/tools/bookmarkManager.js
+++ b/js/tools/bookmarkManager.js
@@ -114,7 +114,7 @@ class BookmarkManager { /*exported BookmarkManager*/
   async _createRootFolder_async() {
     let rootBookmarkId = null;
 
-    let bookmarkItems = await browser.bookmarks.search({title: 'Drop feeds'});
+    let bookmarkItems = await browser.bookmarks.search({title: 'Drop Feeds'});
     if (bookmarkItems) {
       if (bookmarkItems[0]) {
         rootBookmarkId = bookmarkItems[0].id;
@@ -162,7 +162,7 @@ class BookmarkManager { /*exported BookmarkManager*/
   }
 
   async _createDefaultBookmark_async() {
-    let rootBookmark = await browser.bookmarks.create({ title: 'Drop feeds' });
+    let rootBookmark = await browser.bookmarks.create({ title: 'Drop Feeds' });
     await browser.bookmarks.create({
       parentId: rootBookmark.id,
       title: 'The Mozilla Blog',

--- a/js/tools/browserManager.js
+++ b/js/tools/browserManager.js
@@ -47,7 +47,7 @@ class BrowserManager { /* exported BrowserManager*/
     browser.notifications.create({
       'type': 'basic',
       'iconUrl': browser.extension.getURL(ThemeManager.instance.iconDF96Url),
-      'title': 'Drop feeds',
+      'title': 'Drop Feeds',
       'message': message
     });
   }

--- a/js/tools/defaultValues.js
+++ b/js/tools/defaultValues.js
@@ -4,22 +4,24 @@ class DefaultValues { /*exported DefaultValues*/
 
   /*
   */
-  static get asynchronousFeedChecking() { return true; }
-  static get timeOut()                  { return 60; }
-  static get displayRootFolder()        { return true; }
-  static get alwaysOpenNewTab()         { return true; }
-  static get openNewTabForeground()     { return true; }
-  static get rootBookmarkId()           { return undefined; }
-  static get themeFolderName()          { return 'dauphine'; }
-  static get updatedFeedsVisible()      { return false; }
-  static get foldersOpened()            { return true; }
-  static get maxItemsInUnifiedView()    { return 100; }
-  static get feedItemList()             { return false; }
-  static get feedItemListToolbar()      { return false; }
-  static get feedItemDescriptionTooltips() { return false; }
+  static get asynchronousFeedChecking()      { return true; }
+  static get timeOut()                       { return 60; }
+  static get displayRootFolder()             { return true; }
+  static get alwaysOpenNewTab()              { return true; }
+  static get openNewTabForeground()          { return true; }
+  static get rootBookmarkId()                { return undefined; }
+  static get themeFolderName()               { return 'dauphine'; }
+  static get updatedFeedsVisible()           { return false; }
+  static get foldersOpened()                 { return true; }
+  static get maxItemsInUnifiedView()         { return 100; }
+  static get feedItemList()                  { return false; }
+  static get feedItemListToolbar()           { return false; }
+  static get feedItemDescriptionTooltips()   { return false; }
   static get ifHttpsHasFailedRetryWithHttp() { return true; }
   static get currentOptionTabName()          { return 'generalTab'; }
-  static get showFeedUpdatePopup()      { return true; }
+  static get showFeedUpdatePopup()           { return true; }
+  static get automaticFeedUpdates()          { return false; }
+  static get automaticFeedUpdateMinutes()    { return 30; }
 
   static getStoredFolder(folderId) {
     return {id: folderId, checked: true};

--- a/js/ui/options/opmlExporter.js
+++ b/js/ui/options/opmlExporter.js
@@ -37,7 +37,7 @@ class OpmlExporter { /*exported OpmlExporter*/
     indentRef[0] += this._opmlIntentSize;
     headText += TextTools.makeIndent(indentRef[0]) + '<head>\n';
     indentRef[0] += this._opmlIntentSize;
-    headText += TextTools.makeIndent(indentRef[0]) + '<title>Drop feeds OPML Export</title>\n';
+    headText += TextTools.makeIndent(indentRef[0]) + '<title>Drop Feeds OPML Export</title>\n';
     indentRef[0] -= this._opmlIntentSize;
     headText += TextTools.makeIndent(indentRef[0]) +'</head>\n';
     headText += TextTools.makeIndent(indentRef[0]) +'<body>\n';

--- a/js/ui/options/tabUpdateChecker.js
+++ b/js/ui/options/tabUpdateChecker.js
@@ -17,6 +17,14 @@ class TabUpdateChecker { /*exported TabUpdateChecker*/
     let elIfHttpsHasFailedRetryWithHttp = document.getElementById('ifHttpsHasFailedRetryWithHttpCheckbox');
     elIfHttpsHasFailedRetryWithHttp.checked =  await LocalStorageManager.getValue_async('ifHttpsHasFailedRetryWithHttp', DefaultValues.ifHttpsHasFailedRetryWithHttp);
     elIfHttpsHasFailedRetryWithHttp.addEventListener('click', TabUpdateChecker._ifHttpsHasFailedRetryWithHttpCheckboxClicked_event);
+    
+    let elAutomaticFeedUpdates = document.getElementById('automaticFeedUpdatesCheckbox');
+    elAutomaticFeedUpdates.checked =  await LocalStorageManager.getValue_async('automaticFeedUpdates', DefaultValues.automaticFeedUpdates);
+    elAutomaticFeedUpdates.addEventListener('click', TabUpdateChecker._ifAutomaticFeedUpdatesCheckboxClicked_event);
+
+    let elAutomaticFeedUpdateMinutesNumber = document.getElementById('automaticFeedUpdateMinutesNumber');
+    elAutomaticFeedUpdateMinutesNumber.value = await LocalStorageManager.getValue_async('automaticFeedUpdateMinutes', DefaultValues.automaticFeedUpdateMinutes);
+    elAutomaticFeedUpdateMinutesNumber.addEventListener('change', TabUpdateChecker._automaticFeedUpdateMinutesNumberChanged_event);
   }
 
   static async _timeoutValueChanged_event() {
@@ -34,5 +42,14 @@ class TabUpdateChecker { /*exported TabUpdateChecker*/
   
   static async _ifHttpsHasFailedRetryWithHttpCheckboxClicked_event() {
     await LocalStorageManager.setValue_async('ifHttpsHasFailedRetryWithHttp', document.getElementById('ifHttpsHasFailedRetryWithHttpCheckbox').checked);
+  }
+  
+   static async _ifAutomaticFeedUpdatesCheckboxClicked_event() {
+    await LocalStorageManager.setValue_async('automaticFeedUpdates', document.getElementById('automaticFeedUpdatesCheckbox').checked);
+  }
+  
+  static async _automaticFeedUpdateMinutesNumberChanged_event() {
+    let automaticFeedUpdateMinutes = Number(document.getElementById('automaticFeedUpdateMinutesNumber').value);
+    await LocalStorageManager.setValue_async('automaticFeedUpdateMinutes', automaticFeedUpdateMinutes);
   }
 }

--- a/js/ui/sidebar/sidebar.js
+++ b/js/ui/sidebar/sidebar.js
@@ -11,7 +11,7 @@ class SideBar { /*exported SideBar*/
 
   constructor() {
     /*eslint-disable no-console*/
-    console.log('Drop feeds loading...');
+    console.log('Drop Feeds loading...');
     /*eslint-enable no-console*/
     this._contentTop = null;
   }

--- a/js/ui/sidebar/sidebar.js
+++ b/js/ui/sidebar/sidebar.js
@@ -17,6 +17,7 @@ class SideBar { /*exported SideBar*/
   }
 
   async init_async() {
+    await BookmarkManager.instance.init_async();
     await TreeView.instance.load_async();
     await Timeout.instance.init_async();
     await ThemeManager.instance.init_async();
@@ -24,7 +25,6 @@ class SideBar { /*exported SideBar*/
     FeedManager.instance;
     ItemsPanel.instance;
     ItemsPanel.instance.splitterBar.top = window.innerHeight / 2;
-    BookmarkManager.instance.init_async();
     TabManager.instance;
     document.getElementById('main').addEventListener('click', ContextMenu.instance.hide);
     this._addListeners();
@@ -80,4 +80,4 @@ class SideBar { /*exported SideBar*/
 }
 
 SideBar.instance.init_async();
-SideBar.instance.reloadOnce();
+//SideBar.instance.reloadOnce();

--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -72,7 +72,7 @@ class TopMenu  { /*exported TopMenu*/
 
   updatedFeedsSetVisibility() {
     this.activateButton('onlyUpdatedFeedsButton' , this._updatedFeedsVisible);
-    let visibleValue = this._updatedFeedsVisible ? 'display:none;' : 'visibility:visible;';
+    let visibleValue = this._updatedFeedsVisible ? 'display:none !important;' : 'visibility:visible;';
     CssManager.replaceStyle('.feedUnread', '  visibility: visible;\n  font-weight: bold;');
     CssManager.replaceStyle('.feedRead', visibleValue);
     CssManager.replaceStyle('.feedError', visibleValue);

--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -80,6 +80,8 @@ class TopMenu  { /*exported TopMenu*/
   }
 
   async automaticFeedUpdate() {
+      await TopMenu.updateAutomaticUpdateInterval();
+      
       let automaticUpdatesEnabled = await LocalStorageManager.getValue_async('automaticFeedUpdates', DefaultValues.automaticFeedUpdates);
       if (!automaticUpdatesEnabled)
           return;

--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -83,12 +83,16 @@ class TopMenu  { /*exported TopMenu*/
       let automaticUpdatesEnabled = await LocalStorageManager.getValue_async('automaticFeedUpdates', DefaultValues.automaticFeedUpdates);
       if (!automaticUpdatesEnabled)
           return;
-  
-    await TopMenu.updateAutomaticUpdateInterval();
-    
-      try {
+
+      await TopMenu.updateAutomaticUpdateInterval();
+
+      try 
+      {
           await FeedManager.instance.checkFeeds_async('content');
-      } catch(e) {
+      } 
+      catch(e) 
+      {
+          console.log(e);
       }
   }
   
@@ -96,7 +100,7 @@ class TopMenu  { /*exported TopMenu*/
     let automaticUpdatesMinutes = await LocalStorageManager.getValue_async('automaticFeedUpdateMinutes', DefaultValues.automaticFeedUpdateMinutes);
     let automaticUpdatesMilliseconds = Math.min(automaticUpdatesMinutes * 60000, 300000);
 
-    if(TopMenu.instance.autoUpdateInterval || TopMenu.instance.automaticUpdatesMilliseconds != automaticUpdatesMilliseconds)
+    if(TopMenu.instance.automaticUpdatesMilliseconds != automaticUpdatesMilliseconds)
     {
         TopMenu.instance.automaticUpdatesMilliseconds = automaticUpdatesMilliseconds;
         

--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -86,7 +86,6 @@ class TopMenu  { /*exported TopMenu*/
   
     await TopMenu.updateAutomaticUpdateInterval();
     
-    alert("Updating");
       try {
           await FeedManager.instance.checkFeeds_async('content');
       } catch(e) {
@@ -99,7 +98,6 @@ class TopMenu  { /*exported TopMenu*/
 
     if(TopMenu.instance.autoUpdateInterval || TopMenu.instance.automaticUpdatesMilliseconds != automaticUpdatesMilliseconds)
     {
-        alert("Resetting auto update");
         TopMenu.instance.automaticUpdatesMilliseconds = automaticUpdatesMilliseconds;
         
         if(TopMenu.instance.autoUpdateInterval)

--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -14,6 +14,8 @@ class TopMenu  { /*exported TopMenu*/
     this._buttonAddFeedEnabled = false;
     this._buttonDiscoverFeedsEnabled = false;
     this.discoverFeedsButtonEnabled = this._buttonDiscoverFeedsEnabled;
+    this.autoUpdateInterval = undefined;
+    this.automaticUpdatesMilliseconds = undefined;
   }
 
   async init_async() {
@@ -27,6 +29,8 @@ class TopMenu  { /*exported TopMenu*/
     document.getElementById('toggleFoldersButton').addEventListener('click', TopMenu._toggleFoldersButtonClicked_event);
     document.getElementById('addFeedButton').addEventListener('click', TopMenu._addFeedButtonClicked_event);
     document.getElementById('optionsMenuButton').addEventListener('click', TopMenu._optionsMenuClicked_event);
+
+    setTimeout(this.automaticFeedUpdate, 2000);
   }
 
   set discoverFeedsButtonEnabled(value) {
@@ -75,6 +79,36 @@ class TopMenu  { /*exported TopMenu*/
     LocalStorageManager.setValue_async('updatedFeedsVisibility', this._updatedFeedsVisible);
   }
 
+  async automaticFeedUpdate() {
+      let automaticUpdatesEnabled = await LocalStorageManager.getValue_async('automaticFeedUpdates', DefaultValues.automaticFeedUpdates);
+      if (!automaticUpdatesEnabled)
+          return;
+  
+    await TopMenu.updateAutomaticUpdateInterval();
+    
+    alert("Updating");
+      try {
+          await FeedManager.instance.checkFeeds_async('content');
+      } catch(e) {
+      }
+  }
+  
+  static async updateAutomaticUpdateInterval() {
+    let automaticUpdatesMinutes = await LocalStorageManager.getValue_async('automaticFeedUpdateMinutes', DefaultValues.automaticFeedUpdateMinutes);
+    let automaticUpdatesMilliseconds = Math.min(automaticUpdatesMinutes * 60000, 300000);
+
+    if(TopMenu.instance.autoUpdateInterval || TopMenu.instance.automaticUpdatesMilliseconds != automaticUpdatesMilliseconds)
+    {
+        alert("Resetting auto update");
+        TopMenu.instance.automaticUpdatesMilliseconds = automaticUpdatesMilliseconds;
+        
+        if(TopMenu.instance.autoUpdateInterval)
+            clearInterval(TopMenu.instance.autoUpdateInterval);
+        
+        TopMenu.instance.autoUpdateInterval = setInterval(TopMenu.instance.automaticFeedUpdate, automaticUpdatesMilliseconds);
+    }
+  }
+  
   static async checkFeedsButtonClicked_event(event) {
     event.stopPropagation();
     event.preventDefault();
@@ -139,5 +173,9 @@ class TopMenu  { /*exported TopMenu*/
     event.stopPropagation();
     event.preventDefault();
     await browser.runtime.openOptionsPage();
+  }
+  
+  static async _automaticUpdateChanged_event(event) {
+    await TopMenu.updateAutomaticUpdateInterval()
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Drop feeds",
+  "name": "Drop Feeds",
   "description": "Displays a sidebar that lets you manage your RSS feeds in a folder tree view",
   "version": "0.5.3",
   "applications": {
@@ -18,7 +18,7 @@
 
   "sidebar_action": {
     "default_icon": "resources/img/drop-feeds-32.png",
-    "default_title" : "Drop feeds",
+    "default_title" : "Drop Feeds",
     "default_panel": "html/sidebar.html"
   },
 


### PR DESCRIPTION
@dauphine-dev 

I intended this to just be the feed auto update feature, but some other stuff like ```"Drop feeds" -> "Drop Feeds"``` snuck in as well.  I can break this PR out into separate branches if you only want parts of it.  

1. The main improvement is a timed automatic feed update option, like I originally added in Sage++.  This allows for the feed updates to occur every 5 to 1440 minutes (default is Disabled). [94775e62dc0191aad19a421e3d7ed4bcf37a870f, 4a0441fd4dee749e664971ef41d960cf21d27b35, 7764d137f48ed686013e8136e8cfb0a35247561e, 4fa3586bce2ff8201c1bfdabcdefc658869eae2c]

![screen shot 2018-04-21 at 10 18 33 pm](https://user-images.githubusercontent.com/3139346/39091057-281dce82-45b2-11e8-8b45-8ad0c43e74c6.png)

2. I also improved the responsiveness of the "View only updated feeds" feature by forcing the clicked feed to be hidden immediately.  Previously, at least on Windows and Firefox 60, the feed would show as read but not be hidden until you moved the mouse off of that feed item.  [edc5bd9ee7ba01c8e2242afcbd4921fd9f1eaaf9]

3. Another change was reordering BookmarkManager's init to be before TreeView in sidebar.js.  TreeView.load_async() calls BookmarkManager.getRootFolderId_async() but because BookmarkManager's load_async() hasn't yet been called, _rootBookmarkId was undefined.  This caused problems if you weren't using the default feed bookmark.  After changing this I commented out ```SideBar.instance.reloadOnce()``` since it doesn't seem to be necessary any longer, but you might want to double check that part.  [1bde63efae37566146320673696a2ae7ff9faa12]

4. Finally, I changed all of the "Drop feeds" strings to "Drop Feeds" since titles are usually capitalized like that.  This is a breaking change if you are using the default bookmark name, at least until you select it from the Options.  I'm also not sure what affect it will have on the Mozilla extensions library /  manifest.json.  So parts or all of this can be undone - it mostly just a visual improvement.  [5051474c22576163fe29226a4d674155d8dab2dd]
