### PR TITLE
Feed parsing issues

### DIFF
--- a/js/tools/browserManager.js
+++ b/js/tools/browserManager.js
@@ -84,6 +84,8 @@ class BrowserManager { /* exported BrowserManager*/
   }
 
   static async isVisitedLink_async(url) {
+    if(!url)
+        return false;
     var visits = await browser.history.getVisits({url: url});
     return (visits.length > 0);
   }

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -207,7 +207,10 @@ class FeedParser { /*exported FeedParser*/
     }
     if (idIndex < 0) idIndex = 0;
 
-    let startNextItemIndex = feedText.indexOf('<' + tagItem, idIndex + 1);
+    // Search for "<item>" (without attributes) and "<item " (with attributes) 
+    let startNextItemIndex = feedText.indexOf('<' + tagItem + '>', idIndex + 1);
+    if (startNextItemIndex == -1)
+        startNextItemIndex = feedText.indexOf('<' + tagItem + ' ', idIndex + 1);
     if (startNextItemIndex == -1) return '';
     let tagItemEnd = '</' + tagItem + '>';
     let endNextItemIndex = feedText.indexOf(tagItemEnd, startNextItemIndex);

--- a/js/tools/textTools.js
+++ b/js/tools/textTools.js
@@ -32,12 +32,19 @@ class TextTools { /* exported TextTools*/
 
   static decodeHtml(htmlText) {
     if (!htmlText) { return htmlText; }
-    let listEncodedCars = {amp: '&', lt: '<', gt: '>', quot: '"' };
+    let listEncodedCars = {amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
 
     let decodedText = htmlText.replace(/&([^;]+);/g, (l, c) => {
       let decodedCar =  listEncodedCars[c];
       decodedCar = decodedCar ? decodedCar : l;
       return decodedCar; });
+
+    // &#x3C; -> "<", &#x3e; -> ">", etc. 
+    let listHexEncodedChars = {"26": '&', "3C": '<', "3E": '>', "22": '"', "27": "'" };
+    decodedText = decodedText.replace(/&#x([^;]+);/gi, (l, c) => {
+      let decodedChar = listHexEncodedChars[c];
+      decodedChar = decodedChar ? decodedChar : l;
+      return decodedChar; });
 
     decodedText = decodedText.replace(/&#(\d+);/g, function(match, dec) {
       let fromCharCode = String.fromCharCode(dec);


### PR DESCRIPTION
@dauphine-dev 

* cfd446f adds support for feeds that use hex encoded XML escape characters instead of ```&amp;``` or ```&lt;```.  I don't see this a lot but http://www.hot-deals.org/rss/xml/ is one example that renders correctly with this change.  I also noticed that ```&apos;``` was missing from the listEncodedCars associative list and added that.

* 5953a5b improves the item element parsing for RSS 1.0 feeds such as Slashdot (http://rss.slashdot.org/Slashdot/slashdot) and Craigslist (https://ames.craigslist.org/search/bik?format=rss).  These have an <items> element which the previous code would catch because it was searching for ```'<item'```, which would also match on ```<items>```.  This would results in a duplicate first item as shown below:

![screen shot 2018-04-24 at 12 19 18 am](https://user-images.githubusercontent.com/3139346/39167529-30c74c58-4755-11e8-8a47-d1f9d6b1d76f.png)


