### PR TITLE
Don't hide error feeds

### DIFF
--- a/js/ui/sidebar/topMenu.js
+++ b/js/ui/sidebar/topMenu.js
@@ -74,9 +74,10 @@ class TopMenu  { /*exported TopMenu*/
   updatedFeedsSetVisibility() {
     this.activateButton('onlyUpdatedFeedsButton' , this._updatedFeedsVisible);
     let visibleValue = this._updatedFeedsVisible ? 'display:none !important;' : 'visibility:visible;';
-    CssManager.replaceStyle('.feedUnread', '  visibility: visible;\n  font-weight: bold;');
+    let unreadValue = '  visibility: visible;\n  font-weight: bold;'
+    CssManager.replaceStyle('.feedUnread', unreadValue);
     CssManager.replaceStyle('.feedRead', visibleValue);
-    CssManager.replaceStyle('.feedError', visibleValue);
+    CssManager.replaceStyle('.feedError', unreadValue);
     LocalStorageManager.setValue_async('updatedFeedsVisibility', this._updatedFeedsVisible);
   }
 


### PR DESCRIPTION
@dauphine-dev 

Treat 'error' feeds as unread so they are visible even if "View Only Updated Feeds" is enabled