### PR TITLE
Add Podcast Support

### DIFF
--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -418,21 +418,25 @@ class FeedParser { /*exported FeedParser*/
     // RSS enclosure attributes 'url', 'type', 'length'
     let tag = 'enclosure';
     let url = FeedParser._extractAttribute(itemText, tag, ['url']);
-    let mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
-    let size = FeedParser._extractAttribute(itemText, tag, ['length']);
-    if(url && mimetype) {
-        let d = {'url': url, 'mimetype': mimetype, 'size': size};
-        return d;
+    if(url) {
+        let mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
+        if(mimetype) {
+            let size = FeedParser._extractAttribute(itemText, tag, ['length']);
+            let d = {'url': url, 'mimetype': mimetype, 'size': size};
+            return d;
+        }
     }
 
     // MediaRSS attributes 'url', 'type', 'fileSize'
     tag = 'media:content';
     url = FeedParser._extractAttribute(itemText, tag, ['url']);
-    mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
-    size = FeedParser._extractAttribute(itemText, tag, ['fileSize']);
-    if(url && mimetype) {
-        let d = {'url': url, 'mimetype': mimetype, 'size': size};
-        return d;
+    if(url) {
+        let mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
+        if(mimetype) {
+            let size = FeedParser._extractAttribute(itemText, tag, ['fileSize']);
+            let d = {'url': url, 'mimetype': mimetype, 'size': size};
+            return d;
+        }
     }
     
     return null;

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -363,6 +363,7 @@ class FeedParser { /*exported FeedParser*/
       item.description = TextTools.decodeHtml(FeedParser._extractValue(itemText, tagList.DESC));
       item.category = FeedParser._getItemCategory(itemText);
       item.author = TextTools.decodeHtml(FeedParser._extractValue(itemText, tagList.AUTHOR));
+      item.enclosure = FeedParser._getEnclosure(itemText);
       let pubDateText = FeedParser._extractValue(itemText, tagList.PUBDATE);
       item.pubDate = FeedParser._extractDateTime(pubDateText);
       let optionsDateTime = { weekday: 'long', year: 'numeric', month: 'short', day: '2-digit', hour :'2-digit',  minute:'2-digit' };
@@ -413,6 +414,49 @@ class FeedParser { /*exported FeedParser*/
     return category;
   }
 
+  static _getEnclosure(itemText) {
+    // RSS enclosure attributes 'url', 'type', 'length'
+    let tag = 'enclosure';
+    let url = FeedParser._extractAttribute(itemText, tag, ['url']);
+    let mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
+    let size = FeedParser._extractAttribute(itemText, tag, ['length']);
+    if(url && mimetype) {
+        let d = {'url': url, 'mimetype': mimetype, 'size': size};
+        return d;
+    }
+
+    // MediaRSS attributes 'url', 'type', 'fileSize'
+    tag = 'media:content';
+    url = FeedParser._extractAttribute(itemText, tag, ['url']);
+    mimetype = FeedParser._extractAttribute(itemText, tag, ['type']);
+    size = FeedParser._extractAttribute(itemText, tag, ['fileSize']);
+    if(url && mimetype) {
+        let d = {'url': url, 'mimetype': mimetype, 'size': size};
+        return d;
+    }
+    
+    return null;
+  }
+  
+  static _getEnclosureHTML(item) {
+      if(!item || !item.enclosure)
+          return '';
+
+      if(item.enclosure.mimetype.startsWith('audio/')) {
+          let html = '<div class="itemAudioPlayer"><audio preload=none controls><source src="' + item.enclosure.url + '" type="' + item.enclosure.mimetype + '"></audio></div>\n' + 
+                     '<div class="itemEnclosureLink"><a href="' + item.enclosure.url + '" download>' + item.enclosure.url + '</a></div>\n'; 
+          return html;
+      }
+
+      if(item.enclosure.mimetype.startsWith('video/')) {
+          let html = '<div class="itemVideoPlayer"><video width=640 height=480 preload=none controls><source src="' + item.enclosure.url + '" type="' + item.enclosure.mimetype + '"></video></div>\n' + 
+                     '<div class="itemEnclosureLink"><a href="' + item.enclosure.url + '" download>' + item.enclosure.url + '</a></div>\n'; 
+          return html;
+      }
+
+      return '';
+  }
+  
   static _getHtmlItem(item, itemNumber) {
     let htmlItem = '';
     let title = item.title;
@@ -427,6 +471,7 @@ class FeedParser { /*exported FeedParser*/
     if (item.category) { htmlItem +=    '        <div class="itemCat">[' + item.category + ']</div>\n'; }
     if (item.author) { htmlItem +=      '        <div class="itemAuthor">Posted by ' + item.author + '</div>\n'; }
     if (item.pubDate) { htmlItem +=     '        <div class="itemPubDate">' + item.pubDateText + '</div>\n'; }
+    if (item.enclosure) { htmlItem +=   '        <div class="itemEnclosure">' + FeedParser._getEnclosureHTML(item) + ' </div>\n'; }
     htmlItem +=                         '      </div>\n';
     htmlItem +=                         '    </div>\n';
     return htmlItem;

--- a/resources/themes/dauphine/css/feed.css
+++ b/resources/themes/dauphine/css/feed.css
@@ -99,3 +99,6 @@ div.item {
 	color: #7D7D7D;
 }
 
+.itemAudioPlayer audio {
+    width: 75%;
+}

--- a/resources/themes/legacy/css/feed.css
+++ b/resources/themes/legacy/css/feed.css
@@ -88,3 +88,6 @@ div.item {
 	color: #7D7D7D;
 }
 
+.itemAudioPlayer audio {
+    width: 75%;
+}

--- a/resources/themes/sage_sc/css/feed.css
+++ b/resources/themes/sage_sc/css/feed.css
@@ -114,3 +114,7 @@ div.item {
 	top: -1em;
 	width: 15em;
 }
+
+.itemAudioPlayer audio {
+    width: 50%;
+}


### PR DESCRIPTION
@dauphine-dev 

This change adds podcast support to the item HTML rendering, by supporting the RSS 2.0's ```enclosure``` and Media RSS's ```media:content``` elements.  

Audio and Video podcasts are supported inline as well as linking to the content.  I don't automatically retrieve metadata to avoid unnecessary network traffic (especially for video content), but this might be a good option or two to add in future work ("Retrieve Audio Metadata" / "Retrieve Video Metadata").


![screen shot 2018-05-06 at 10 47 19 pm](https://user-images.githubusercontent.com/3139346/39684207-b8d8befe-517f-11e8-8156-a1f5f0a2f1f7.png)
(screenshot is slightly out of date - I applied the CSS style to make the audio player wider in all 3 skins)

![screen shot 2018-05-06 at 10 47 49 pm](https://user-images.githubusercontent.com/3139346/39684210-be8e39be-517f-11e8-85b4-dd8de8ee24fa.png)
