### PR TITLE
sage-sc selectionbar height

### DIFF
--- a/resources/themes/sage_sc/css/sidebar.css
+++ b/resources/themes/sage_sc/css/sidebar.css
@@ -518,7 +518,7 @@ li {
 .selectionBar {
   position: absolute;
   top: 0px;
-  height: 17px;
+  height: 20px;
   width: 100%;
   margin-top: -5px;
   background-color: #448bd6;


### PR DESCRIPTION
@dauphine-dev 

Minor change to increase the height of the sage-sc theme's selectionbar, so that it better covers the list item.