### PR TITLE
Reuse Drop Feeds Tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -355,7 +355,10 @@
   "optOpenNewTabForeground": {
     "message": "Open new tab in foreground"
   },
-
+  "optReuseDropFeedsTab": {
+    "message": "Reuse Drop Feeds tab"
+  },
+  
   "optSelectOpmlFileToImport": {
     "message": "Select the opml file to import"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -356,6 +356,9 @@
   "optOpenNewTabForeground": {
     "message": "Ouvrir les nouveaux onglets en avant plan"
   },
+  "optReuseDropFeedsTab": {
+    "message": "Reuse Drop Feeds tab"
+  },
 
   "optSelectOpmlFileToImport": {
     "message": "Sélectionnez le fichier opml à importer"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -352,6 +352,9 @@
   "optOpenNewTabForeground": {
     "message": "新しいタブを手前で開く"
   },
+  "optReuseDropFeedsTab": {
+    "message": "Reuse Drop Feeds tab"
+  },
 
   "optSelectOpmlFileToImport": {
     "message": "opmlのインポート"

--- a/html/options.html
+++ b/html/options.html
@@ -134,10 +134,20 @@
     <div id="contentsAreaTab" class="tabContent">
       <table>
         <tr>
-          <td><input type="checkbox" id="renderFeedsCheckbox"><span id="textRenderFeeds" class="checkboxText">#Render feeds</span></td>
-          <td><input type="checkbox" id="alwaysOpenNewTabCheckbox"><span id="textAlwaysOpenNewTab" class="checkboxText">#Always open new tab</span></td>
-          <td><input type="checkbox" id="reuseDropFeedsTabCheckbox"><span id="textReuseDropFeedsTab" class="checkboxText">#Reuse Drop Feeds tab</span></td>
-          <td><input type="checkbox" id="openNewTabForegroundCheckbox"><span id="textOpenNewTabForeground" class="checkboxText">#Open new tab in foreground</span></td>
+          <td>
+            <input type="checkbox" id="renderFeedsCheckbox"><span id="textRenderFeeds" class="checkboxText">#Render feeds</span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <span><input type="checkbox" id="alwaysOpenNewTabCheckbox"><span id="textAlwaysOpenNewTab" class="checkboxText">#Always open new tab</span></span>
+            <span><input type="checkbox" id="reuseDropFeedsTabCheckbox"><span id="textReuseDropFeedsTab" class="checkboxText">#Reuse Drop Feeds tab</span></span>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <input type="checkbox" id="openNewTabForegroundCheckbox"><span id="textOpenNewTabForeground" class="checkboxText">#Open new tab in foreground</span>
+          </td>
         </tr>
       </table>
     </div>

--- a/html/options.html
+++ b/html/options.html
@@ -136,6 +136,7 @@
         <tr>
           <td><input type="checkbox" id="renderFeedsCheckbox"><span id="textRenderFeeds" class="checkboxText">#Render feeds</span></td>
           <td><input type="checkbox" id="alwaysOpenNewTabCheckbox"><span id="textAlwaysOpenNewTab" class="checkboxText">#Always open new tab</span></td>
+          <td><input type="checkbox" id="reuseDropFeedsTabCheckbox"><span id="textReuseDropFeedsTab" class="checkboxText">#Reuse Drop Feeds tab</span></td>
           <td><input type="checkbox" id="openNewTabForegroundCheckbox"><span id="textOpenNewTabForeground" class="checkboxText">#Open new tab in foreground</span></td>
         </tr>
       </table>

--- a/js/tools/browserManager.js
+++ b/js/tools/browserManager.js
@@ -39,18 +39,17 @@ class BrowserManager { /* exported BrowserManager*/
   async openTab_async(url, openNewTabForce, openNewTabBackGroundForce) {
     let activeTab = await BrowserManager.getActiveTab_async();
     let dfTab = null;
-    let activeTabIsDfTab = dfTab && dfTab.id == activeTab.id;
     let openNewTab = this._alwaysOpenNewTab || openNewTabForce;
     let openNewTabForeground = openNewTabBackGroundForce ? false : this._openNewTabForeground;
     let reuseDropFeedsTab = this._reuseDropFeedsTab;
-    
+
     if (BrowserManager.isDropFeedsTab(activeTab)) {
         dfTab = activeTab;
     }
     else {
         dfTab = await BrowserManager.findDropFeedsTab_async();
     }
-    
+
     // Open Tab Logic:
     //   1. "Always Open in New Tab" == True || openNewTabForce == True
     //     a. "Reuse Drop Feed Tabs" == False
@@ -66,7 +65,8 @@ class BrowserManager { /* exported BrowserManager*/
     //        -> Create new tab and make it active
     let doCreate = this._alwaysOpenNewTab;
     let targetTabId = activeTab.id;
-    
+    let activeTabIsDfTab = dfTab && dfTab.id == activeTab.id;
+
     if(openNewTab) {
         // Option 1 - (Usually) open a new tab
         let isEmptyActiveTab = await BrowserManager.isTabEmpty_async(activeTab);
@@ -78,7 +78,7 @@ class BrowserManager { /* exported BrowserManager*/
             // Option 1b - New tab unless active tab is empty or DF tab
             doCreate = !isEmptyActiveTab || !activeTabIsDfTab; 
         }
-    }        
+    }
     else {
         // Option 2 - (Usually) update an existing tab
         if(!reuseDropFeedsTab) {

--- a/js/tools/browserManager.js
+++ b/js/tools/browserManager.js
@@ -11,11 +11,12 @@ class BrowserManager { /* exported BrowserManager*/
   constructor() {
     this._alwaysOpenNewTab = DefaultValues.alwaysOpenNewTab;
     this._openNewTabForeground = DefaultValues.openNewTabForeground;
-    this._reuseDropFeedTab = DefaultValues.reuseDropFeedTab;
+    this._reuseDropFeedsTab = DefaultValues.reuseDropFeedsTab;
     this._baseFeedUrl = null;
     
     Listener.instance.subscribe(ListenerProviders.localStorage, 'alwaysOpenNewTab', BrowserManager._setAlwaysOpenNewTab_sbscrb, true);
     Listener.instance.subscribe(ListenerProviders.localStorage, 'openNewTabForeground', BrowserManager._setOpenNewTabForeground_sbscrb, true);
+    Listener.instance.subscribe(ListenerProviders.localStorage, 'reuseDropFeedsTab', BrowserManager._setReuseDropFeedsTab_sbscrb, true);
   }
 
   //non statics
@@ -41,7 +42,7 @@ class BrowserManager { /* exported BrowserManager*/
     let activeTabIsDfTab = dfTab && dfTab.id == activeTab.id;
     let openNewTab = this._alwaysOpenNewTab || openNewTabForce;
     let openNewTabForeground = openNewTabBackGroundForce ? false : this._openNewTabForeground;
-    let reuseDropFeedTab = this._reuseDropFeedTab;
+    let reuseDropFeedsTab = this._reuseDropFeedsTab;
     
     // Open Tab Logic:
     //   1. "Always Open in New Tab" == True || openNewTabForce == True
@@ -62,7 +63,7 @@ class BrowserManager { /* exported BrowserManager*/
     if(openNewTab) {
         // Option 1 - (Usually) open a new tab
         let isEmptyActiveTab = await BrowserManager.isTabEmpty_async(activeTab);
-        if(!reuseDropFeedTab) {
+        if(!reuseDropFeedsTab) {
             // Option 1a - New tab unless active tab is empty
             doCreate = !isEmptyActiveTab;
         }
@@ -73,7 +74,7 @@ class BrowserManager { /* exported BrowserManager*/
     }        
     else {
         // Option 2 - (Usually) update an existing tab
-        if(!reuseDropFeedTab) {
+        if(!reuseDropFeedsTab) {
             // Option 2a - Update the current active tab
             doCreate = false;
         }
@@ -243,6 +244,10 @@ class BrowserManager { /* exported BrowserManager*/
 
   static _setOpenNewTabForeground_sbscrb(value){
     BrowserManager.instance._openNewTabForeground = value;
+  }
+
+  static _setReuseDropFeedsTab_sbscrb(value) {
+    BrowserManager.instance._reuseDropFeedsTab = value;
   }
 
   static async _forcePopupToDisplayContent_async(winId, winWidth) {

--- a/js/tools/browserManager.js
+++ b/js/tools/browserManager.js
@@ -11,6 +11,9 @@ class BrowserManager { /* exported BrowserManager*/
   constructor() {
     this._alwaysOpenNewTab = DefaultValues.alwaysOpenNewTab;
     this._openNewTabForeground = DefaultValues.openNewTabForeground;
+    this._reuseDropFeedTab = DefaultValues.reuseDropFeedTab;
+    this._baseFeedUrl = null;
+    
     Listener.instance.subscribe(ListenerProviders.localStorage, 'alwaysOpenNewTab', BrowserManager._setAlwaysOpenNewTab_sbscrb, true);
     Listener.instance.subscribe(ListenerProviders.localStorage, 'openNewTabForeground', BrowserManager._setOpenNewTabForeground_sbscrb, true);
   }
@@ -20,15 +23,79 @@ class BrowserManager { /* exported BrowserManager*/
     return this._alwaysOpenNewTab;
   }
 
+  get baseFeedUrl() {
+    // Returns the "blob:moz-extension://<Internal UUID>" feed base URL for this installation
+    if (this._baseFeedUrl) {
+        return this._baseFeedUrl;
+    }
+
+    let feedBlob = new Blob([]);
+    let feedUrl = new URL(URL.createObjectURL(feedBlob));
+    this._baseFeedUrl = feedUrl.protocol + feedUrl.origin;
+    return this._baseFeedUrl ;
+  }
+  
   async openTab_async(url, openNewTabForce, openNewTabBackGroundForce) {
     let activeTab = await BrowserManager.getActiveTab_async();
-    let isEmptyActiveTab = await BrowserManager.isTabEmpty_async(activeTab);
+    let dfTab = await BrowserManager.findDropFeedsTab_async();
+    let activeTabIsDfTab = dfTab && dfTab.id == activeTab.id;
     let openNewTab = this._alwaysOpenNewTab || openNewTabForce;
-    if(openNewTab && !isEmptyActiveTab) {
-      let openNewTabForeground = openNewTabBackGroundForce ? false : this._openNewTabForeground;
-      await browser.tabs.create({url: url, active: openNewTabForeground});
-    } else {
-      await browser.tabs.update(activeTab.id, {url: url});
+    let openNewTabForeground = openNewTabBackGroundForce ? false : this._openNewTabForeground;
+    let reuseDropFeedTab = this._reuseDropFeedTab;
+    
+    // Open Tab Logic:
+    //   1. "Always Open in New Tab" == True || openNewTabForce == True
+    //     a. "Reuse Drop Feed Tabs" == False
+    //        -> Open a new tab, unless the active tab is empty
+    //     b. "Reuse Drop Feed Tabs" == True
+    //        -> Open a new tab unless the active tab is empty or an existing DF tab
+    //   2. "Always Open in New Tab" == False
+    //     a. "Reuse Drop Feed Tabs" == False
+    //        -> Update the current active tab
+    //     b. "Reuse Drop Feed Tabs" == True && there is one or more DF tabs
+    //        -> Update the first Drop Feeds tab and make it active.
+    //     c. "Reuse Drop Feed Tabs" == True && no existing DF tab
+    //        -> Create new tab and make it active
+    let doCreate = this._alwaysOpenNewTab;
+    let targetTabId = activeTab.id;
+    
+    if(openNewTab) {
+        // Option 1 - (Usually) open a new tab
+        let isEmptyActiveTab = await BrowserManager.isTabEmpty_async(activeTab);
+        if(!reuseDropFeedTab) {
+            // Option 1a - New tab unless active tab is empty
+            doCreate = !isEmptyActiveTab;
+        }
+        else {
+            // Option 1b - New tab unless active tab is empty or DF tab
+            doCreate = !isEmptyActiveTab || !activeTabIsDfTab; 
+        }
+    }        
+    else {
+        // Option 2 - (Usually) update an existing tab
+        if(!reuseDropFeedTab) {
+            // Option 2a - Update the current active tab
+            doCreate = false;
+        }
+        else {
+            // Option 2b - Update the first DF tab
+            if(dfTab) {
+                doCreate = false;
+                targetTabId = dfTab.id;
+            }
+            else {
+                // Option 2c - Create a new tab and activate it
+                doCreate = true;
+                openNewTabForeground = true;
+            }
+        }
+    }
+
+    if(doCreate) {
+        await browser.tabs.create({url: url, active: openNewTabForeground});
+    }
+    else {
+        await browser.tabs.update(targetTabId, {url: url, active: openNewTabForeground});
     }
   }
 
@@ -45,11 +112,10 @@ class BrowserManager { /* exported BrowserManager*/
   }
 
   static async getActiveTab_async() {
-    var windowInfo = await browser.windows.getLastFocused();
-    let tabInfos = await browser.tabs.query({active: true, windowId: windowInfo.id});
+    let tabInfos = await browser.tabs.query({active: true, currentWindow: true});
     return tabInfos[0];
   }
-
+ 
   static displayNotification(message) {
     browser.notifications.create({
       'type': 'basic',
@@ -155,6 +221,21 @@ class BrowserManager { /* exported BrowserManager*/
     return isFeed;
   }
 
+  static async findDropFeedsTab_async() {
+    let tabs = await browser.tabs.query({currentWindow: true}) 
+    if(tabs) {
+        let baseUrl = BrowserManager.instance.baseFeedUrl;
+        for (var i = 0, len = tabs.length; i < len; i++) {
+            let url = tabs[i].url;
+            if(url.startsWith(baseUrl)) {
+                return tabs[i];
+            }
+        }
+    }
+
+    return null;
+  }
+  
   //private stuffs
   static _setAlwaysOpenNewTab_sbscrb(value){
     BrowserManager.instance._alwaysOpenNewTab = value;

--- a/js/tools/defaultValues.js
+++ b/js/tools/defaultValues.js
@@ -7,7 +7,7 @@ class DefaultValues { /*exported DefaultValues*/
   static get displayRootFolder()             { return true; }
   static get alwaysOpenNewTab()              { return true; }
   static get openNewTabForeground()          { return true; }
-  static get reuseDropFeedTab()              { return true; }
+  static get reuseDropFeedsTab()             { return false; }
   static get rootBookmarkId()                { return undefined; }
   static get themeFolderName()               { return 'legacy'; }
   static get updatedFeedsVisible()           { return false; }

--- a/js/tools/defaultValues.js
+++ b/js/tools/defaultValues.js
@@ -7,6 +7,7 @@ class DefaultValues { /*exported DefaultValues*/
   static get displayRootFolder()             { return true; }
   static get alwaysOpenNewTab()              { return true; }
   static get openNewTabForeground()          { return true; }
+  static get reuseDropFeedTab()              { return true; }
   static get rootBookmarkId()                { return undefined; }
   static get themeFolderName()               { return 'legacy'; }
   static get updatedFeedsVisible()           { return false; }

--- a/js/ui/options/tabContentArea.js
+++ b/js/ui/options/tabContentArea.js
@@ -19,6 +19,7 @@ class TabContentArea { /*exported TabContentArea*/
     let elReuseDropFeedsTabCheckbox = document.getElementById('reuseDropFeedsTabCheckbox');
     elReuseDropFeedsTabCheckbox.checked =  await LocalStorageManager.getValue_async('reuseDropFeedsTab', DefaultValues.reuseDropFeedsTab);
     elReuseDropFeedsTabCheckbox.addEventListener('click', TabContentArea._reuseDropFeedsTabCheckboxClicked_event);
+    TabContentArea._updateReuseDropFeedsCheckboxDisabled();
   }
 
   static _updateLocalizedStrings() {
@@ -34,6 +35,7 @@ class TabContentArea { /*exported TabContentArea*/
 
   static async _alwaysOpenNewTabCheckBoxClicked_event() {
     await LocalStorageManager.setValue_async('alwaysOpenNewTab', document.getElementById('alwaysOpenNewTabCheckbox').checked);
+    TabContentArea._updateReuseDropFeedsCheckboxDisabled();
   }
 
   static async _openNewTabForegroundCheckboxClicked_event() {
@@ -42,5 +44,11 @@ class TabContentArea { /*exported TabContentArea*/
   
   static async _reuseDropFeedsTabCheckboxClicked_event() {
     await LocalStorageManager.setValue_async('reuseDropFeedsTab', document.getElementById('reuseDropFeedsTabCheckbox').checked);
+  }
+  
+  static _updateReuseDropFeedsCheckboxDisabled() {
+    let elAlwaysOpenNewTabCheckbox = document.getElementById('alwaysOpenNewTabCheckbox');
+    let elReuseDropFeedsTabCheckbox = document.getElementById('reuseDropFeedsTabCheckbox');
+    elReuseDropFeedsTabCheckbox.disabled = elAlwaysOpenNewTabCheckbox.checked;
   }
 }

--- a/js/ui/options/tabContentArea.js
+++ b/js/ui/options/tabContentArea.js
@@ -11,16 +11,21 @@ class TabContentArea { /*exported TabContentArea*/
     let elAlwaysOpenNewTabCheckbox = document.getElementById('alwaysOpenNewTabCheckbox');
     elAlwaysOpenNewTabCheckbox.checked =  await LocalStorageManager.getValue_async('alwaysOpenNewTab', DefaultValues.alwaysOpenNewTab);
     elAlwaysOpenNewTabCheckbox.addEventListener('click', TabContentArea._alwaysOpenNewTabCheckBoxClicked_event);
-    let elOpenNewTabForegroundCheckbox = document.getElementById('openNewTabForegroundCheckbox');
 
+    let elOpenNewTabForegroundCheckbox = document.getElementById('openNewTabForegroundCheckbox');
     elOpenNewTabForegroundCheckbox.checked =  await LocalStorageManager.getValue_async('openNewTabForeground', DefaultValues.openNewTabForeground);
     elOpenNewTabForegroundCheckbox.addEventListener('click', TabContentArea._openNewTabForegroundCheckboxClicked_event);
+    
+    let elReuseDropFeedsTabCheckbox = document.getElementById('reuseDropFeedsTabCheckbox');
+    elReuseDropFeedsTabCheckbox.checked =  await LocalStorageManager.getValue_async('reuseDropFeedsTab', DefaultValues.reuseDropFeedsTab);
+    elReuseDropFeedsTabCheckbox.addEventListener('click', TabContentArea._reuseDropFeedsTabCheckboxClicked_event);
   }
 
   static _updateLocalizedStrings() {
     document.getElementById('textRenderFeeds').textContent = browser.i18n.getMessage('optRenderFeeds');
     document.getElementById('textAlwaysOpenNewTab').textContent = browser.i18n.getMessage('optAlwaysOpenNewTab');
     document.getElementById('textOpenNewTabForeground').textContent = browser.i18n.getMessage('optOpenNewTabForeground');
+    document.getElementById('textReuseDropFeedsTab').textContent = browser.i18n.getMessage('optReuseDropFeedsTab');
   }
 
   static async _renderFeedsCheckBoxClicked_event() {
@@ -33,5 +38,9 @@ class TabContentArea { /*exported TabContentArea*/
 
   static async _openNewTabForegroundCheckboxClicked_event() {
     await LocalStorageManager.setValue_async('openNewTabForeground', document.getElementById('openNewTabForegroundCheckbox').checked);
+  }
+  
+  static async _reuseDropFeedsTabCheckboxClicked_event() {
+    await LocalStorageManager.setValue_async('reuseDropFeedsTab', document.getElementById('reuseDropFeedsTabCheckbox').checked);
   }
 }


### PR DESCRIPTION
@dauphine-dev 

This change adds a variation on the "Always open new tab" option which causes Drop Feeds to open a new tab unless there is an existing Drop Feeds tab.  In that case, that Drop Feeds tab is reused/updated and optionally made active if the "Open new tab in foreground" option is enabled.

The idea here is to avoid Drop Feeds replacing a website content tab with a rendered feed, but without opening a bunch of tabs as you get with "Always open new tab".  This is noticable on slow loading content since you may have navigated away to some other page and then the rendered feed content overwrites it.  

![screen shot 2018-05-21 at 10 32 41 pm](https://user-images.githubusercontent.com/3139346/40340824-e8d2c5f0-5d46-11e8-8faa-0d55939e663d.png)

Demo screencast: https://gfycat.com/EmbarrassedLastAbyssiniancat 