### PR TITLE
Potential fix for non UTF-8 encoded feeds

### DIFF
--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -339,7 +339,7 @@ class FeedParser { /*exported FeedParser*/
   static _getHtmlHead(channel) {
     let iconUrl = browser.extension.getURL(ThemeManager.instance.iconDF32Url);
     let cssUrl = browser.extension.getURL(ThemeManager.instance.getCssUrl('feed.css'));
-    let encoding = channel.encoding ? channel.encoding : 'UTF-8';
+    let encoding = 'utf-16'; // DOMString's default encoding - convertion is now done in downloadTextFileEx_async()
     let htmlHead = '';
     htmlHead                      += '<html>\n';
     htmlHead                      += '  <head>\n';

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -339,7 +339,7 @@ class FeedParser { /*exported FeedParser*/
   static _getHtmlHead(channel) {
     let iconUrl = browser.extension.getURL(ThemeManager.instance.iconDF32Url);
     let cssUrl = browser.extension.getURL(ThemeManager.instance.getCssUrl('feed.css'));
-    let encoding = 'utf-16'; // DOMString's default encoding - convertion is now done in downloadTextFileEx_async()
+    let encoding = 'utf-8'; // Convertion is now done in downloadTextFileEx_async()
     let htmlHead = '';
     htmlHead                      += '<html>\n';
     htmlHead                      += '  <head>\n';

--- a/js/tools/transfer.js
+++ b/js/tools/transfer.js
@@ -1,4 +1,4 @@
-/*global DefaultValues LocalStorageManager Listener ListenerProviders*/
+/*global DefaultValues LocalStorageManager Listener ListenerProviders FeedParser*/
 'use strict';
 class Timeout { /*exported Timeout*/
   static get instance() {
@@ -49,11 +49,30 @@ class Transfer { /*exported Transfer*/
   static async downloadTextFileEx_async(url, urlNoCache) {
     return new Promise((resolve, reject) => {
       let xhr = new XMLHttpRequest();
-      xhr.responseType = 'text';
+      xhr.responseType = 'arraybuffer';
       xhr.onloadend = function() {
         if (xhr.readyState === XMLHttpRequest.DONE) {
           if (xhr.status === 200) {
-            resolve(xhr.responseText);
+            // Decode the response as UTF-8 then apply the feed's specified encoding (if present)
+            let defaultEncoding = 'utf-8';
+            let response = new DataView(xhr.response);
+            let utf8Decoder = new TextDecoder(defaultEncoding);
+            let utf8Content = utf8Decoder.decode(response);
+            try {
+              let encoding = FeedParser._getEncoding(utf8Content);
+              if (encoding && encoding != defaultEncoding) {
+                let decoder = new TextDecoder(encoding.toLowerCase());
+                let decodedContent = decoder.decode(response);
+                resolve(decodedContent);
+              }
+            }
+            catch(e) {
+              /*eslint-disable no-console*/
+              console.log('downloadTextFileEx_async encoding failed "' + e);
+              /*eslint-enable no-console*/
+            }
+            // Fallback to the default encoding
+            resolve(utf8Content);
           }
           else {
             let statusText = xhr.statusText ? xhr.statusText : 'unknown error';


### PR DESCRIPTION
@dauphine-dev 

This is a potential fix for the issue reported in https://github.com/dauphine-dev/drop-feeds/issues/22 . We now retrieve the feed as binary, convert it to UTF-8 and parse out the feed's own encoding (if any), then decode using that.  

I haven't tested this very much at all and text encoding is always a pain, so we'll want to make sure it works consistently on all feed types...


![screen shot 2018-05-28 at 4 51 51 pm](https://user-images.githubusercontent.com/3139346/40630659-f454274a-6299-11e8-931e-3963da49c2c3.png)

![screen shot 2018-05-28 at 5 21 42 pm](https://user-images.githubusercontent.com/3139346/40630815-a63b2d72-629b-11e8-89ac-6bc1554c98e9.png)

![screen shot 2018-05-28 at 5 23 14 pm](https://user-images.githubusercontent.com/3139346/40630832-da9c42f4-629b-11e8-9645-7e211a101730.png)
