### PR TITLE
Disable unwanted HTML content in the feed description

### DIFF
--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -566,6 +566,14 @@ class FeedParser { /*exported FeedParser*/
     if (diff > 0) {
       text += '</div>'.repeat(diff);
     }
+
+    // Perform basic sanitization of the HTML content to disable unwanted content
+    // TODO: replace with a real sanitization code and/or a whitelist of allowed tags
+    let blackList = ['iframe', 'script', 'embed', 'object', 'link'];
+    for (let tag of blackList) {
+      text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds');
+    }
+
     return text;
   }
 }

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -569,9 +569,9 @@ class FeedParser { /*exported FeedParser*/
 
     // Perform basic sanitization of the HTML content to disable unwanted content
     // TODO: replace with a real sanitization code and/or a whitelist of allowed tags
-    let blackList = ['iframe', 'script', 'embed', 'object', 'link'];
+    let blackList = ['iframe', 'script', 'embed', 'object', 'link', 'audio', 'video'];
     for (let tag of blackList) {
-      text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds');
+      text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds style="display:none">');
     }
 
     return text;

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -569,9 +569,14 @@ class FeedParser { /*exported FeedParser*/
 
     // Perform basic sanitization of the HTML content to disable unwanted content
     // TODO: replace with a real sanitization code and/or a whitelist of allowed tags
-    let blackList = ['iframe', 'script', 'embed', 'object', 'link', 'audio', 'video'];
-    for (let tag of blackList) {
+    let blackListShow = ['blink', 'marquee'];
+    let blackListHide = ['audio', 'canvas', 'embed', 'form', 'iframe', 'input', 'link', 'menu', 'object', 'script', 'video'];    
+    for (let tag of blackListShow) {
+      text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds>');
+    }
+    for (let tag of blackListHide) {
       text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds style="display:none">');
+      text = text.replace(new RegExp('<\s*/' + tag, 'gi'), '</' + tag + '-blocked-by-dropfeeds');
     }
 
     return text;


### PR DESCRIPTION
@dauphine-dev 

This is a very basic bit of code to disable unwanted HTML in feed description content.  It is mostly useful for preventing autoplaying videos and other annoying items, but isn't designed to handle purposefully malicious HTML.