### PR TITLE
Skip empty strings when sanitizing description tags

### DIFF
--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -614,6 +614,8 @@ class FeedParser { /*exported FeedParser*/
 
   static _disableTags(text, tagToDisableList, hide) {
     for (let tag of tagToDisableList) {
+      if(!tag)
+          continue;
       text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds' + (hide ? ' style="display:none"' : ''));
       text = text.replace(new RegExp('<\\s*/' + tag, 'gi'), '</' + tag + '-blocked-by-dropfeeds');
     }

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -615,7 +615,7 @@ class FeedParser { /*exported FeedParser*/
   static _disableTags(text, tagToDisableList, hide) {
     for (let tag of tagToDisableList) {
       if(!tag)
-          continue;
+        continue;
       text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds' + (hide ? ' style="display:none"' : ''));
       text = text.replace(new RegExp('<\\s*/' + tag, 'gi'), '</' + tag + '-blocked-by-dropfeeds');
     }

--- a/js/tools/feedParser.js
+++ b/js/tools/feedParser.js
@@ -614,8 +614,7 @@ class FeedParser { /*exported FeedParser*/
 
   static _disableTags(text, tagToDisableList, hide) {
     for (let tag of tagToDisableList) {
-      if(!tag)
-        continue;
+      if (!tag) { continue; }
       text = text.replace(new RegExp('<' + tag, 'gi'), '<' + tag + '-blocked-by-dropfeeds' + (hide ? ' style="display:none"' : ''));
       text = text.replace(new RegExp('<\\s*/' + tag, 'gi'), '</' + tag + '-blocked-by-dropfeeds');
     }


### PR DESCRIPTION
@dauphine-dev 

I noticed that some feeds were getting corrupted by the whitelist security filter.  For example, the first article currently on https://blog.netbsd.org/tnf/feed/entries/atom looks like this:

![screen shot 2018-08-26 at 12 39 06 pm](https://user-images.githubusercontent.com/3139346/44631105-5933f580-a92d-11e8-86ed-68592ab123a3.png) with the feed XML:

```
<content type="html">&lt;p&gt;
As introduced in &lt;a href=&quot; http://blog.netbsd.org/tnf/entry/gsoc_2018_reports_configuration_files1&quot;&gt;GSoC 2018 Reports: Configuration files versioning in pkgsrc, part 2: remote repositories (git and CVS)&lt;/a&gt; pkgsrc supports using some version control system repositories to search for site-specific configuration for packages being installed, and deploys it on the system. 
&lt;/p&gt;
```

Another example is the "https://thedailywtf.com/articles/is-this-terning-into-a-date" article on http://thedailywtf.com/rss.aspx


I think there are also some issues with _applySecurityFilters()'s textTagList because it is ```p,a,h2,code,pre,6,eof,``` for that first article, but I was able to get this to render correctly by just ignoring an empty tag string in _disableTags()'s loop.


Original HTML:
```
<div class="itemDescription"><-blocked-by-dropfeeds style="display:none"p>
As introduced in <-blocked-by-dropfeeds style="display:none"a href=" http://blog.netbsd.org/tnf/entry/gsoc_2018_reports_configuration_files1">GSoC 2018 Reports: Configuration files versioning in pkgsrc, part 2: remote repositories (git and CVS)<-blocked-by-dropfeeds style="display:none"/a> pkgsrc supports using some version control system repositories to search for site-specific configuration for packages being installed, and deploys it on the system. 
<-blocked-by-dropfeeds style="display:none"/p>
```

HTML renders correctly with this change:
```
<div class="itemDescription"><p>
As introduced in <a href=" http://blog.netbsd.org/tnf/entry/gsoc_2018_reports_configuration_files1">GSoC 2018 Reports: Configuration files versioning in pkgsrc, part 2: remote repositories (git and CVS)</a> pkgsrc supports using some version control system repositories to search for site-specific configuration for packages being installed, and deploys it on the system. 
</p>
``` 
 