### PR TITLE
Update the "Reuse Drop Feeds Tab" checkbox behavior

### DIFF
--- a/js/ui/options/tabContentArea.js
+++ b/js/ui/options/tabContentArea.js
@@ -99,7 +99,7 @@ class TabContentArea { /*exported TabContentArea*/
   _enableItemOptions() {
     let enabled = document.getElementById('renderFeedsCheckbox').checked;
     this._enableElement('contentsAreaTabOptionsFieldset', null, enabled);
-    this._enableElement('reuseDropFeedsTabCheckbox', 'textReuseDropFeedsTab', enabled && document.getElementById('alwaysOpenNewTabCheckbox').checked);
+    this._enableElement('reuseDropFeedsTabCheckbox', 'textReuseDropFeedsTab', enabled);
     this._enableElement('contentsDateTimeFieldset', null, enabled);
   }
 


### PR DESCRIPTION
@dauphine-dev 

This change simplifies the "Reuse Drop Feeds tab" checkbox behavior.  It used to be disabled if "Always open in new tab" was unchecked but it really doesn't need to be and can be confusing.  