### PR TITLE
Specify the default font family for the sidebar items as sans-serif

### DIFF
--- a/themes/_templates/css/sidebar.css
+++ b/themes/_templates/css/sidebar.css
@@ -12,6 +12,7 @@ html, body {
   white-space: nowrap;
   overflow: hidden;
   line-height: 16px;
+  font-family: sans-serif;
 }
 
 /* misc. */


### PR DESCRIPTION
@dauphine-dev 

While testing 1.0.17.1.beta3 (thanks for merging and updating the lock UI feature!), I noticed that the feed items were now rendered using a Serif font on macOS only - Windows was unchanged.  

So I added an explicit `font-family`, which fixes macOS but also had a minor impact, at least on my Windows machine.  You might want to specify a font by name(s) if you find the change too invasive.


Before (1.0.17.1.beta3):
<img width="317" alt="Screen Shot 2023-09-30 at 10 11 29 PM" src="https://github.com/dauphine-dev/drop-feeds/assets/3139346/f41aa403-9a9c-404a-800d-ffa7d814322b">

After:
<img width="307" alt="Screen Shot 2023-09-30 at 10 08 06 PM" src="https://github.com/dauphine-dev/drop-feeds/assets/3139346/41df246b-d485-40a8-b0e7-2d69f1c9cf80">

